### PR TITLE
fix(docs/snippets): Adding guidebooks to docs/snippets

### DIFF
--- a/docs/snippets/docker-guidebook.md
+++ b/docs/snippets/docker-guidebook.md
@@ -1,0 +1,8 @@
+### [Docker](https://docs.docker.com/get-docker/)
+
+```bash
+---
+validate: $body
+---
+(docker info >& /dev/null) && echo “You have Docker!” || (echo “Please install Docker” && exit 1)
+```

--- a/docs/snippets/kind-guidebook.md
+++ b/docs/snippets/kind-guidebook.md
@@ -1,0 +1,9 @@
+### [kind](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker)
+Enables you to run a local Kubernetes cluster with Docker container nodes.
+
+```bash
+---
+validate: $body
+---
+(kind version >& /dev/null) && echo "You have Kind!"|| echo "Please install Kind"
+```

--- a/docs/snippets/kn-cli-guidebook.md
+++ b/docs/snippets/kn-cli-guidebook.md
@@ -1,0 +1,10 @@
+### The Knative CLI (`kn`) 
+
+```bash
+---
+validate: $body
+---
+(kn version >& /dev/null) && echo "You have the Knative CLI" | echo "Please install the Knative CLI"
+```
+
+--8<-- "https://raw.githubusercontent.com/mra-ruiz/docs/main/docs/snippets/install-kn.md"

--- a/docs/snippets/kubectl-guidebook.md
+++ b/docs/snippets/kubectl-guidebook.md
@@ -1,0 +1,9 @@
+### The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank} 
+Runs commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
+
+```bash
+---
+validate: $body
+---
+(kubectl version --client >& /dev/null) && echo "You have kubectl!" || echo "Please install kubectl"
+```


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adding guidebooks for docker, kind, kn-cli, and Kubectl which will be hash included in ```docs/snippets/quickstart-install.md```
