### PR TITLE
swap order of imports, so that kn and kubectl appear before knative

### DIFF
--- a/docs/guidebooks/knative-serving-hello-world.md
+++ b/docs/guidebooks/knative-serving-hello-world.md
@@ -6,9 +6,9 @@ layout:
     default: wizard
 imports:
     - docs/snippets/docker-guidebook.md
-    - docs/install/README.md
-    - docs/snippets/install-kn.md
     - docs/snippets/kubectl-guidebook.md
+    - docs/snippets/install-kn.md
+    - docs/install/README.md
 wizard:
     steps:
         - name: Install Required Tools


### PR DESCRIPTION
This PR permutes the order of the imports so that we get this ordering in the guidebooks tree:

install kubectl
install kn
install knative